### PR TITLE
Add support for verifying webhook signatures

### DIFF
--- a/lib/stripe/errors/signature_verification_error.ex
+++ b/lib/stripe/errors/signature_verification_error.ex
@@ -1,0 +1,6 @@
+defmodule Stripe.SignatureVerificationError do
+  @moduledoc """
+  Failure to verify payload with signature attached to webhook requests.
+  """
+  defstruct type: "signature_verification_error", message: nil
+end

--- a/lib/stripe/webhook.ex
+++ b/lib/stripe/webhook.ex
@@ -1,0 +1,98 @@
+defmodule Stripe.Webhook do
+  alias Stripe.SignatureVerificationError
+
+  @default_tolerance 300
+  @expected_scheme "v1"
+
+  def construct_event(payload, signature_header, secret, tolerance \\ @default_tolerance) do
+    case verify_header(payload, signature_header, secret, tolerance) do
+      :ok ->
+        {:ok, Poison.decode!(payload)}
+      error ->
+        error
+    end
+  end
+
+  defp verify_header(payload, signature_header, secret, tolerance) do
+    case get_timestamp_and_signatures(signature_header, @expected_scheme) do
+      {nil, _} ->
+        {:error, %SignatureVerificationError{message: "Unable to extract timestamp and signatures from header"}}
+
+      {_, []} ->
+        {:error, %SignatureVerificationError{message: "No signatures found with expected scheme #{@expected_scheme}"}}
+
+      {timestamp, signatures} ->
+        with {:ok, timestamp} <- check_timestamp(timestamp, tolerance),
+             {:ok, _signatures} <- check_signatures(signatures, timestamp, payload, secret) do
+          :ok
+        else
+          {:error, error} -> {:error, error}
+        end
+    end
+  end
+
+  defp get_timestamp_and_signatures(signature_header, scheme) do
+    signature_header
+    |> String.split(",")
+    |> Enum.map(& String.split(&1, "="))
+    |> Enum.reduce({nil, []}, fn
+      ["t", timestamp], {nil, signatures} ->
+        {to_integer(timestamp), signatures}
+
+      [^scheme, signature], {timestamp, signatures} ->
+        {timestamp, [signature | signatures]}
+
+      _, acc ->
+        acc
+    end)
+  end
+
+  defp to_integer(timestamp) do
+    case Integer.parse(timestamp) do
+      {timestamp, _} ->
+        timestamp
+      :error ->
+        nil
+    end
+  end
+
+  defp check_timestamp(timestamp, tolerance) do
+    now = System.system_time(:seconds)
+    if timestamp < (now - tolerance) do
+      {:error, %SignatureVerificationError{message: "Timestamp outside the tolerance zone (#{now})"}}
+    else
+      {:ok, timestamp}
+    end
+  end
+
+  defp check_signatures(signatures, timestamp, payload, secret) do
+    signed_payload = "#{timestamp}.#{payload}"
+    expected_signature = compute_signature(signed_payload, secret)
+    if Enum.any?(signatures, & secure_equals?(&1, expected_signature)) do
+      {:ok, signatures}
+    else
+      {:error, %SignatureVerificationError{message: "No signatures found matching the expected signature for payload"}}
+    end
+  end
+
+  defp compute_signature(payload, secret) do
+    :crypto.hmac(:sha256, secret, payload)
+    |> Base.encode16(case: :lower)
+  end
+
+  defp secure_equals?(input, expected) when byte_size(input) == byte_size(expected) do
+    input = String.to_charlist(input)
+    expected = String.to_charlist(expected)
+    secure_compare(input, expected)
+  end
+  defp secure_equals?(_, _), do: false
+
+  defp secure_compare(acc \\ 0, input, expected)
+  defp secure_compare(acc, [], []), do: acc == 0
+  defp secure_compare(acc, [input_codepoint | input], [expected_codepoint | expected]) do
+    import Bitwise
+    acc
+    |> bor(input_codepoint ^^^ expected_codepoint)
+    |> secure_compare(input, expected)
+  end
+end

--- a/test/webhook_test.exs
+++ b/test/webhook_test.exs
@@ -1,0 +1,75 @@
+defmodule Stripe.WebhookTest do
+  use ExUnit.Case, async: true
+
+  alias Stripe.Webhook
+
+  @payload ~S({"object": "event"})
+
+  @valid_scheme "v1"
+  @invalid_scheme "v0"
+
+  @secret "secret"
+
+  defp generate_signature(timestamp, payload, secret \\ @secret) do
+    :crypto.hmac(:sha256, secret, "#{timestamp}.#{payload}")
+    |> Base.encode16(case: :lower)
+  end
+
+  defp create_signature_header(timestamp, scheme, signature) do
+    "t=#{timestamp},#{scheme}=#{signature}"
+  end
+
+  test "payload with a valid signature should return event" do
+    timestamp = System.system_time(:seconds)
+    payload = @payload
+    signature = generate_signature(timestamp, payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:ok, _} = Webhook.construct_event(payload, signature_header, @secret)
+  end
+
+  test "payload with invalid timestamp should fail" do
+    timestamp = "abc"
+    payload = @payload
+    signature = generate_signature(timestamp, payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:error, %Stripe.SignatureVerificationError{}} = Webhook.construct_event(payload, signature_header, @secret)
+  end
+
+  test "payload with expired timestamp should fail" do
+    timestamp = 1
+    payload = @payload
+    signature = generate_signature(timestamp, payload)
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:error, %Stripe.SignatureVerificationError{}} = Webhook.construct_event(payload, signature_header, @secret)
+  end
+
+  test "payload with an invalid signature should fail" do
+    timestamp = System.system_time(:seconds)
+    payload = @payload
+    signature = generate_signature(timestamp, "random")
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:error, %Stripe.SignatureVerificationError{}} = Webhook.construct_event(payload, signature_header, @secret)
+  end
+
+  test "payload with wrong secret should fail" do
+    timestamp = System.system_time(:seconds)
+    payload = @payload
+    signature = generate_signature(timestamp, payload, "wrong")
+    signature_header = create_signature_header(timestamp, @valid_scheme, signature)
+
+    assert {:error, %Stripe.SignatureVerificationError{}} = Webhook.construct_event(payload, signature_header, @secret)
+  end
+
+  test "payload with missing signature scheme should fail" do
+    timestamp = System.system_time(:seconds)
+    payload = @payload
+    signature = generate_signature(timestamp, payload)
+    signature_header = create_signature_header(timestamp, @invalid_scheme, signature)
+
+    assert {:error, %Stripe.SignatureVerificationError{}} = Webhook.construct_event(payload, signature_header, @secret)
+  end
+end


### PR DESCRIPTION
Official Stripe libraries provide a [`construct_event`](https://stripe.com/docs/webhooks#verify-official-libraries) function to verify webhook signatures.

This PR ports this function to Elixir.
```elixir
{:ok, event} = Stripe.Webhook.construct_event(payload, signature_header, secret)
```
It's useful in plugs that handle Stripe webhooks, for example.