### PR TITLE
Support Poison 3.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Stripe.Mixfile do
 
   defp deps do
     [{:httpoison, "~> 0.11"},
-     {:poison, "~> 2.2"},
+     {:poison, "~> 2.2 or ~> 3.0"},
 
      # Docs
      {:ex_doc, "~> 0.10", only: :dev},


### PR DESCRIPTION
Support Poison 3.0 too like Phoenix 1.3.

Also, Poison 4.0 seems to be on the verge of release (see devinus/poison#134).