### PR TITLE
Update Stripe Account creation in tests

### DIFF
--- a/test/connect/account_test.exs
+++ b/test/connect/account_test.exs
@@ -2,7 +2,7 @@ defmodule Stripe.AccountTest do
   use ExUnit.Case
 
   test "create/update/retrieve/delete an account" do
-    assert {:ok, account} = Stripe.Account.create(managed: true)
+    assert {:ok, account} = Stripe.Account.create(type: "custom")
     assert {:ok, %{"email" => _email}} = Stripe.Account.retrieve(account["id"])
     assert {:ok, %{"metadata" => %{"test" => "data"}}} =
       Stripe.Account.update(account["id"], metadata: [test: "data"])
@@ -15,7 +15,7 @@ defmodule Stripe.AccountTest do
   end
 
   test "create/update/retrieve/delete/list an external_account" do
-    {:ok, account} = Stripe.Account.create(managed: true)
+    {:ok, account} = Stripe.Account.create(type: "custom")
 
     {:ok, token} = Stripe.Token.create(
       card: [


### PR DESCRIPTION
As of version 2017-05-25, the `managed` property is no longer supported.

https://stripe.com/docs/upgrades#2017-05-25