### PR TITLE
Refactor tests to remove duplication and fix brittle tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Stripe.Mixfile do
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     elixirc_paths: elixirc_paths(Mix.env),
      deps: deps(),
      package: package(),
      description: description()]
@@ -26,6 +27,8 @@ defmodule Stripe.Mixfile do
       links: %{"GitHub" => "https://github.com/sikanhe/stripe-elixir"}
     ]
   end
+
+  defp elixirc_paths(env) when env in [:dev, :test, :prod], do: ["lib", "test/support"]
 
   def application do
     [extra_applications: [:logger]]

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Stripe.Mixfile do
     ]
   end
 
-  defp elixirc_paths(env) when env in [:dev, :test, :prod], do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   def application do
     [extra_applications: [:logger]]

--- a/test/customer_test.exs
+++ b/test/customer_test.exs
@@ -1,5 +1,6 @@
 defmodule Stripe.CustomerTest do
   use ExUnit.Case, async: true
+  import Stripe.TokenHelpers
 
   alias Stripe.{Customer, Token}
   alias Stripe.InvalidRequestError
@@ -29,14 +30,7 @@ defmodule Stripe.CustomerTest do
   end
 
   test "list cards", %{customer: customer} do
-    {:ok, token} = Token.create(
-      card: [
-        number: "4242424242424242",
-        exp_month: 8,
-        exp_year: 2019,
-        cvc: "143"
-      ]
-    )
+    {:ok, token} = valid_card() |> Token.create()
 
     assert {:ok, %{"id" => _source_id, "object" => "card"}} =
       Customer.create_card(customer["id"], token["id"])
@@ -52,14 +46,7 @@ defmodule Stripe.CustomerTest do
   end
 
   test "add/update/delete a card to a customer", %{customer: customer} do
-    {:ok, token} = Token.create(
-      card: [
-        number: "4242424242424242",
-        exp_month: 7,
-        exp_year: 2017,
-        cvc: "314"
-      ]
-    )
+    {:ok, token} = valid_card() |> Token.create()
 
     assert {:ok, %{"id" => source_id, "object" => "card"}} =
       Customer.create_card(customer["id"], token["id"])

--- a/test/customer_test.exs
+++ b/test/customer_test.exs
@@ -1,7 +1,7 @@
 defmodule Stripe.CustomerTest do
   use ExUnit.Case, async: true
-  import Stripe.Fixture.Token
-
+  
+  alias Stripe.Fixture.Token, as: TokenFixture
   alias Stripe.{Customer, Token}
   alias Stripe.InvalidRequestError
 
@@ -30,7 +30,7 @@ defmodule Stripe.CustomerTest do
   end
 
   test "list cards", %{customer: customer} do
-    {:ok, token} = valid_card() |> Token.create()
+    {:ok, token} = TokenFixture.valid_card() |> Token.create()
 
     assert {:ok, %{"id" => _source_id, "object" => "card"}} =
       Customer.create_card(customer["id"], token["id"])
@@ -46,7 +46,7 @@ defmodule Stripe.CustomerTest do
   end
 
   test "add/update/delete a card to a customer", %{customer: customer} do
-    {:ok, token} = valid_card() |> Token.create()
+    {:ok, token} = TokenFixture.valid_card() |> Token.create()
 
     assert {:ok, %{"id" => source_id, "object" => "card"}} =
       Customer.create_card(customer["id"], token["id"])

--- a/test/customer_test.exs
+++ b/test/customer_test.exs
@@ -1,6 +1,6 @@
 defmodule Stripe.CustomerTest do
   use ExUnit.Case, async: true
-  import Stripe.TokenHelpers
+  import Stripe.Fixture.Token
 
   alias Stripe.{Customer, Token}
   alias Stripe.InvalidRequestError

--- a/test/subscriptions/invoice_test.exs
+++ b/test/subscriptions/invoice_test.exs
@@ -1,6 +1,6 @@
 defmodule Stripe.InvoiceTest do
   use ExUnit.Case, async: true
-  import Stripe.TokenHelpers
+  import Stripe.Fixture.Token
   alias Stripe.{Customer, Token, Invoice, InvoiceItem}
 
   setup_all do

--- a/test/subscriptions/invoice_test.exs
+++ b/test/subscriptions/invoice_test.exs
@@ -1,12 +1,12 @@
 defmodule Stripe.InvoiceTest do
   use ExUnit.Case, async: true
-  import Stripe.Fixture.Token
+  alias Stripe.Fixture.Token, as: TokenFixture
   alias Stripe.{Customer, Token, Invoice, InvoiceItem}
 
   setup_all do
     {:ok, customer} = Customer.create([])
 
-    {:ok, card} = valid_card() |> Token.create()
+    {:ok, card} = TokenFixture.valid_card() |> Token.create()
 
     Customer.create_card(customer["id"], card["id"])
 

--- a/test/subscriptions/invoice_test.exs
+++ b/test/subscriptions/invoice_test.exs
@@ -1,18 +1,12 @@
 defmodule Stripe.InvoiceTest do
   use ExUnit.Case, async: true
+  import Stripe.TokenHelpers
   alias Stripe.{Customer, Token, Invoice, InvoiceItem}
 
   setup_all do
     {:ok, customer} = Customer.create([])
 
-    {:ok, card} = Token.create(
-      card: [
-        number: "4242424242424242",
-        exp_month: 7,
-        exp_year: 2017,
-        cvc: "111"
-      ]
-    )
+    {:ok, card} = valid_card() |> Token.create()
 
     Customer.create_card(customer["id"], card["id"])
 

--- a/test/subscriptions/subscription_test.exs
+++ b/test/subscriptions/subscription_test.exs
@@ -1,13 +1,14 @@
 defmodule Stripe.SubscriptionTest do
   use ExUnit.Case, async: true
-  import Stripe.Fixture.Token
+
+  alias Stripe.Fixture.Token, as: TokenFixture
   alias Stripe.{Subscription, Plan, Customer, Token}
   alias Stripe.InvalidRequestError
 
   setup do
     {:ok, customer} = Customer.create([])
 
-    {:ok, card} = valid_card() |> Token.create()
+    {:ok, card} = TokenFixture.valid_card() |> Token.create()
 
     Customer.create_card(customer["id"], card["id"])
 

--- a/test/subscriptions/subscription_test.exs
+++ b/test/subscriptions/subscription_test.exs
@@ -1,19 +1,13 @@
 defmodule Stripe.SubscriptionTest do
   use ExUnit.Case, async: true
+  import Stripe.TokenHelpers
   alias Stripe.{Subscription, Plan, Customer, Token}
   alias Stripe.InvalidRequestError
 
   setup do
     {:ok, customer} = Customer.create([])
 
-    {:ok, card} = Token.create(
-      card: [
-        number: "4242424242424242",
-        exp_month: 7,
-        exp_year: 2017,
-        cvc: "314"
-      ]
-    )
+    {:ok, card} = valid_card() |> Token.create()
 
     Customer.create_card(customer["id"], card["id"])
 

--- a/test/subscriptions/subscription_test.exs
+++ b/test/subscriptions/subscription_test.exs
@@ -1,6 +1,6 @@
 defmodule Stripe.SubscriptionTest do
   use ExUnit.Case, async: true
-  import Stripe.TokenHelpers
+  import Stripe.Fixture.Token
   alias Stripe.{Subscription, Plan, Customer, Token}
   alias Stripe.InvalidRequestError
 

--- a/test/support/token_fixture.ex
+++ b/test/support/token_fixture.ex
@@ -1,4 +1,4 @@
-defmodule Stripe.TokenHelpers do
+defmodule Stripe.Fixture.Token do
 
   def valid_card() do
     %{card: [

--- a/test/support/token_helpers.ex
+++ b/test/support/token_helpers.ex
@@ -1,0 +1,28 @@
+defmodule Stripe.TokenHelpers do
+
+  def valid_card() do
+    %{card: [
+      number: "4242424242424242",
+      exp_month: exp_month(),
+      exp_year: exp_year(),
+      cvc: "314"
+    ]}
+  end
+
+  def invalid_card() do
+    %{card: [
+      number: "invalid card number",
+      exp_month: exp_month(),
+      exp_year: exp_year(),
+      cvc: "314"
+    ]}
+  end
+
+  defp exp_month() do
+    7
+  end
+
+  defp exp_year() do
+    DateTime.utc_now.year + 1
+  end
+end

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -1,31 +1,18 @@
 defmodule Stripe.TokenTest do
   use ExUnit.Case, async: true
+  import Stripe.TokenHelpers
 
   alias Stripe.Token
   alias Stripe.{InvalidRequestError, CardError}
 
   test "create a token" do
-    assert {:ok, token} = Token.create(
-      card: [
-        number: "4242424242424242",
-        exp_month: 7,
-        exp_year: 2017,
-        cvc: "314"
-      ]
-    )
+    assert {:ok, token} = valid_card() |> Token.create()
 
     assert {:ok, ^token} = Token.retrieve(token["id"])
   end
 
   test "card error" do
-    assert {:error, %CardError{param: "number", code: "incorrect_number"}} = Token.create(
-      card: [
-        number: "invalid card number",
-        exp_month: 7,
-        exp_year: 2017,
-        cvc: "314"
-      ]
-    )
+    assert {:error, %CardError{param: "number", code: "incorrect_number"}} = invalid_card() |> Token.create()
   end
 
   test "retrieve a token" do

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -1,6 +1,6 @@
 defmodule Stripe.TokenTest do
   use ExUnit.Case, async: true
-  import Stripe.TokenHelpers
+  import Stripe.Fixture.Token
 
   alias Stripe.Token
   alias Stripe.{InvalidRequestError, CardError}

--- a/test/token_test.exs
+++ b/test/token_test.exs
@@ -1,18 +1,18 @@
 defmodule Stripe.TokenTest do
   use ExUnit.Case, async: true
-  import Stripe.Fixture.Token
 
+  alias Stripe.Fixture.Token, as: TokenFixture
   alias Stripe.Token
   alias Stripe.{InvalidRequestError, CardError}
 
   test "create a token" do
-    assert {:ok, token} = valid_card() |> Token.create()
+    assert {:ok, token} = TokenFixture.valid_card() |> Token.create()
 
     assert {:ok, ^token} = Token.retrieve(token["id"])
   end
 
   test "card error" do
-    assert {:error, %CardError{param: "number", code: "incorrect_number"}} = invalid_card() |> Token.create()
+    assert {:error, %CardError{param: "number", code: "incorrect_number"}} = TokenFixture.invalid_card() |> Token.create()
   end
 
   test "retrieve a token" do


### PR DESCRIPTION
Refactoring tests to remove duplication of card data and prevent needing to update the expiration dates every few months to a year.