### PR TITLE
Add guard clause to update method, ensure id is a string

### DIFF
--- a/lib/stripe/api.ex
+++ b/lib/stripe/api.ex
@@ -24,7 +24,7 @@ defmodule Stripe.API do
         @doc """
         Update a(n) #{__MODULE__ |> to_string |> String.split(".") |> List.last}
         """
-        def update(id, data, opts \\ []) do
+        def update(id, data, opts \\ []) when is_bitstring(id) do
           resource_url = Path.join(endpoint(), id)
           Stripe.request(:post, resource_url, data, opts)
         end


### PR DESCRIPTION
Add guard clause to update method in the API. It was causing weird errors with Path when passing a customer id that was not a string.