### PR TITLE
Add secret_key as request option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ config :stripe, :secret_key, <YOUR_SECRET_KEY>
 export STRIPE_SECRET_KEY=<YOUR_SECRET_KEY>
 ```
 
+or you can pass it as a request option:
+
+```elixir
+Stripe.Charge.create(charge, secret_key: YOUR_SECRET_KEY)
+```
+
 ## Basic Usage
 
 This lib closely follows the official Ruby Client API.
@@ -45,7 +51,7 @@ This lib closely follows the official Ruby Client API.
 
 Returns `{:ok, RESPONSE_BODY}` when the request is successful.
 
-`{:error, %ERROR_STRUCT{}}` tuples are returned when there is a request/api error.  
+`{:error, %ERROR_STRUCT{}}` tuples are returned when there is a request/api error.
 See all error types at https://stripe.com/docs/api/ruby#errors
 
 ## Some Basic Examples
@@ -67,7 +73,7 @@ Stripe.Customer.create([{"email", "example@gmail.com"}])
 
 Retrieve that customer:
 
-```elixir   
+```elixir
 {:ok, customer} = Stripe.Customer.retrieve("cus_asdfghjkl")
 ```
 
@@ -92,9 +98,9 @@ To perform a Direct Charge on a connected stripe account, simply pass :stripe_ac
 Stripe.Charge.create([customer: "cus_asdfghjkl", amount: 400], stripe_account: "acct_sOMeAcCountId")
 ```
 
-#### Generate a Connect authorization url via `Stripe.Connect.authorize_url/1`. 
+#### Generate a Connect authorization url via `Stripe.Connect.authorize_url/1`.
 
-```elixir 
+```elixir
 Stripe.Connect.authorize_url([
   redirect_uri: <OPTIONAL CALLBACK URL>,
   state: <OPTIONAL CSRF TOKEN>,
@@ -102,10 +108,10 @@ Stripe.Connect.authorize_url([
 ])
 ```
 
-#### Options: 
-- `redirect_uri`: An optional callback url after authorization succeeds. 
+#### Options:
+- `redirect_uri`: An optional callback url after authorization succeeds.
 - `state`: You can protect your request from CSRF attacks by passing a csrf token.
-- `client_id`: You can pass in an optional client_id to be used for this url. Defaults to `STRIPE_CLIENT_ID` environment variable or `config :stripe, :client_id` config value. 
+- `client_id`: You can pass in an optional client_id to be used for this url. Defaults to `STRIPE_CLIENT_ID` environment variable or `config :stripe, :client_id` config value.
 
 
 ## Handling Webhooks

--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -26,17 +26,25 @@ defmodule Stripe do
     Alternatively, you can also set the secret key as an environment variable:
 
       STRIPE_SECRET_KEY=YOUR_SECRET_KEY
+
+    or you can pass it as a request option:
+
+    Stripe.Charge.create(charge, secret_key: YOUR_SECRET_KEY)
   """
 
-  defp get_secret_key do
-    System.get_env("STRIPE_SECRET_KEY") || 
-    Application.get_env(:stripe, :secret_key) || 
-    raise AuthenticationError, message: @missing_secret_key_error_message
+  defp get_secret_key(opts) do
+    case Keyword.get(opts, :secret_key) do
+      nil ->
+        System.get_env("STRIPE_SECRET_KEY") ||
+        Application.get_env(:stripe, :secret_key) ||
+        raise AuthenticationError, message: @missing_secret_key_error_message
+      secret_key -> secret_key
+    end
   end
 
   defp get_api_endpoint do
-    System.get_env("STRIPE_API_ENDPOINT") || 
-    Application.get_env(:stripe, :api_endpoint) || 
+    System.get_env("STRIPE_API_ENDPOINT") ||
+    Application.get_env(:stripe, :api_endpoint) ||
     @default_api_endpoint
   end
 
@@ -55,13 +63,13 @@ defmodule Stripe do
   end
 
   defp create_headers(opts) do
-    headers = 
-      [{"Authorization", "Bearer #{get_secret_key()}"},
+    headers =
+      [{"Authorization", "Bearer #{get_secret_key(opts)}"},
        {"User-Agent", "Stripe/v1 stripe-elixir/#{@client_version}"},
        {"Content-Type", "application/x-www-form-urlencoded"}]
 
-    case Keyword.get(opts, :stripe_account) do 
-      nil -> headers 
+    case Keyword.get(opts, :stripe_account) do
+      nil -> headers
       account_id -> [{"Stripe-Account", account_id} | headers]
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Stripe.Mixfile do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.9.0"
 
   def project do
     [app: :stripe,


### PR DESCRIPTION
Adds secret_key as a request option so that you can dynamically switch between test and live mode.