### PR TITLE
Return {:error, ...} tuple for failed requests

### DIFF
--- a/lib/stripe.ex
+++ b/lib/stripe.ex
@@ -99,7 +99,7 @@ defmodule Stripe do
   end
 
   defp handle_response({:error, %HTTPoison.Error{reason: reason}}) do
-    %APIConnectionError{message: "Network Error: #{reason}"}
+    {:error, %APIConnectionError{message: "Network Error: #{reason}"}}
   end
 
   defp process_response_body(body) do


### PR DESCRIPTION
It seems like failed requests should return the same type as the other Stripe errors cases. 