### PR TITLE
Support HTTPoison 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Stripe.Mixfile do
 
   defp deps do
     [
-      {:httpoison, "~> 0.11"},
+      {:httpoison, "~> 0.11 and ~> 1.0"},
       {:poison, "~> 2.2 or ~> 3.0"},
 
       # Docs


### PR DESCRIPTION
HTTPoison 1.0 has been out since 7 January and other packages have bumped to `~> 1.0`.

There are no breaking changes between [0.11 and 1.0](https://github.com/edgurgel/httpoison/compare/174c672b343eccf7df4ee1078c4a44df5ddfdfd7...28024b4b440b4678dfc253f636539b9f56ac217b).